### PR TITLE
Add new idea

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,7 +27,6 @@ $(document).ready(function(){
 
   });
 
-
   function renderIdeas(ideas){
     console.table(ideas);
     var ideasSortedByDate = ideas.sort(function(a, b){
@@ -56,5 +55,38 @@ $(document).ready(function(){
     else {
       return bodyText;
     }
-  }
+  };
+
+  $('#create-idea').on('click', function(){
+    var newIdeaTitle = $('#new-idea-title').val();
+    var newIdeaBody = $('#new-idea-body').val();
+    var postData = { title: newIdeaTitle, body: newIdeaBody  };
+
+    $.ajax({
+      type: 'POST',
+      url: '/api/v1/ideas.json',
+      dataType: 'json',
+      data: postData,
+      success: prependNewIdea,
+      error: function (req, status, err ){
+        console.log('something went wrong when posting', status, err);
+      }
+    });
+
+    $('#new-idea-title').val("Title");
+    $('#new-idea-body').val("Body");
+
+  });
+
+
+  function prependNewIdea(newIdea){
+    $('.ideas-table tr:first').after(
+      "<tr class='ideas-list'>" +
+      "<td class='idea-title' data-idea-id='" + newIdea.id + "'>" + newIdea.title + "</td>" +
+      "<td class='ideas-body' data-idea-id='" + newIdea.id + "'>" + formatBody(newIdea.body) + "</td>" +
+      "<td class='ideas-quality' data-idea-id='" + newIdea.id + "'>" + newIdea.quality +
+      "</td>" +
+      "</tr>"
+    );
+  };
 })

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -2,4 +2,14 @@ class Api::V1::IdeasController < Api::ApiController
   def index
     respond_with Idea.all
   end
+
+  def create
+    respond_with Idea.create(idea_params), location: nil
+  end
+
+  private
+
+    def idea_params
+      params.permit(:title, :body)
+    end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,15 @@
 <h1>Idea Box</h1>
+
+<div class="new-idea">
+  <form method="post">
+    Title:<br>
+    <input type="text" name="title" value="Title"><br>
+    Body:<br>
+    <input type="text" name="body" value="Body"><br><br>
+    <input type="submit" value="Save">
+  </form>
+</div>
+
 <div class="ideas-index">
   <table class = "ideas-table">
     <tr class = "ideas-index-headers">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,13 +1,9 @@
 <h1>Idea Box</h1>
 
 <div class="new-idea">
-  <form method="post">
-    Title:<br>
-    <input type="text" name="title" value="Title"><br>
-    Body:<br>
-    <input type="text" name="body" value="Body"><br><br>
-    <input type="submit" value="Save">
-  </form>
+  <input type="text" name="title" value="Title"><br>
+  <input type="text" name="body" value="Body"><br><br>
+  <input type="submit" value="Save">
 </div>
 
 <div class="ideas-index">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,9 @@
 <h1>Idea Box</h1>
 
 <div class="new-idea">
-  <input type="text" name="title" value="Title"><br>
-  <input type="text" name="body" value="Body"><br><br>
-  <input type="submit" value="Save">
+  <input type="text" name="title" value="Title" id="new-idea-title"><br>
+  <input type="text" name="body" value="Body" id="new-idea-body"><br><br>
+  <input type="button" name="save" value="Save" id="create-idea">
 </div>
 
 <div class="ideas-index">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :ideas, only: [:index]
+      resources :ideas, only: [:index, :create]
     end
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -7,5 +7,9 @@ FactoryGirl.define do
     trait :genius_idea do
       quality 2
     end
+
+    trait :plausible_idea do
+      quality 1
+    end
   end
 end

--- a/spec/features/user_can_add_new_ideas_spec.rb
+++ b/spec/features/user_can_add_new_ideas_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "User can add new ideas", type: :feature do
+  xscenario "user can add a new idea upon submission" do
+    visit root_path
+
+    
+#     On the application's main page, a user should:
+#
+# See two text boxes for entering the "Title" and "Body" for a new idea, and a "Save" button for committing that idea. (3 points, mandatory for specification adherence)
+# When a user clicks "Save":
+#
+# A new idea with the provided title and body should appear in the idea list. (5 points, mandatory for specification adherence)
+# The text fields should be cleared and ready to accept a new idea. (2 points)
+# The page should not reload. (3 points, mandatory for specification adherence)
+# The idea should be committed to the database. It should still be present upon reloading the page. (2 points, mandatory for specification adherence)
+  end
+
+end

--- a/spec/features/user_can_add_new_ideas_spec.rb
+++ b/spec/features/user_can_add_new_ideas_spec.rb
@@ -2,9 +2,24 @@ require 'rails_helper'
 
 RSpec.describe "User can add new ideas", type: :feature do
   xscenario "user can add a new idea upon submission" do
+    existing_idea = create(:idea)
+    new_idea = { title: "New idea title", body: "New idea body" }
+
     visit root_path
 
-    
+    within('.new-idea') do
+      fill_in "Title", with: new_idea[:title]
+      fill_in "Body", with: new_idea[:body]
+      click_button("Save")
+    end
+
+    within('.idea-index') do
+      expect(page).to have_content(new_idea[:title])
+      expect(page).to have_content(new_idea[:body])
+      expect(page).to have_content(existing_idea.title)
+      expect(page).to have_content(existing_idea.body)
+    end
+
 #     On the application's main page, a user should:
 #
 # See two text boxes for entering the "Title" and "Body" for a new idea, and a "Save" button for committing that idea. (3 points, mandatory for specification adherence)

--- a/spec/requests/api_v1_ideas_controllers_spec.rb
+++ b/spec/requests/api_v1_ideas_controllers_spec.rb
@@ -24,4 +24,26 @@ RSpec.describe "Api::V1::IdeasController", type: :request do
       expect(response_body.last[:quality]).to eq(@genius_idea.quality)
     end
   end
+
+  describe "POST idea" do
+    before(:each) do
+      @swill_idea = create(:idea)
+      @genius_idea = create(:idea, :genius_idea)
+      @plausible_idea = create(:idea, :plausible_idea)
+      @new_idea = { title: "New Idea", body: "Body of new idea" }
+
+      post "/api/v1/ideas?title=#{@new_idea[:title]}&body=#{@new_idea[:body]}"
+    end
+
+    it "returns a response with for creating idea" do
+      expect(response).to have_http_status(201)
+      expect(response).to be_success
+    end
+
+    it "creates the idea" do
+      expect(@swill_idea[:title]).not_to eq(@new_idea[:title])
+      expect(Idea.last.title).to eq(@new_idea[:title])
+      expect(response_body[:title]).to eq(@new_idea[:title])
+    end
+  end
 end


### PR DESCRIPTION
User can add new idea, 
- A new idea with the provided title and body should appear in the idea list.
- The text fields should be cleared and ready to accept a new idea.
- The page should not reload.
- The idea should be committed to the database. It should still be present upon reloading the page. 
