### PR TITLE
Delete existing idea feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -99,9 +99,6 @@ $(document).ready(function(){
       url: "/api/v1/ideas/" + ideaId + ".json",
       dataType: "JSON",
       success: function(){
-
-        // having trouble capturing response data
-        // 'this' does not provide idea id that can be used to enable removal
         idea.remove();
       },
       error: function(req, status, err){

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,10 +19,10 @@ $(document).ready(function(){
   $.ajax({
     type: 'GET',
     url: '/api/v1/ideas.json',
-    dataType: 'json',
+    dataType: 'JSON',
     success: renderIdeas,
     error: function( req, status, err ) {
-      console.log( 'something went wrong', status, err );
+      console.log( 'something went wrong in retrieving ideas index', status, err );
     }
 
   });
@@ -42,6 +42,7 @@ $(document).ready(function(){
         "<td class='ideas-body' data-idea-id='" + object.id + "'>" + formatBody(object.body) + "</td>" +
         "<td class='ideas-quality' data-idea-id='" + object.id + "'>" + object.quality +
         "</td>" +
+        "<td><a href='#' class='delete-idea' data-idea-id='" + object.id + "'>Delete</a></td>" +
         "</tr>"
       );
     });
@@ -65,7 +66,7 @@ $(document).ready(function(){
     $.ajax({
       type: 'POST',
       url: '/api/v1/ideas.json',
-      dataType: 'json',
+      dataType: 'JSON',
       data: postData,
       success: prependNewIdea,
       error: function (req, status, err ){
@@ -78,7 +79,6 @@ $(document).ready(function(){
 
   });
 
-
   function prependNewIdea(newIdea){
     $('.ideas-table tr:first').after(
       "<tr class='ideas-list'>" +
@@ -86,7 +86,28 @@ $(document).ready(function(){
       "<td class='ideas-body' data-idea-id='" + newIdea.id + "'>" + formatBody(newIdea.body) + "</td>" +
       "<td class='ideas-quality' data-idea-id='" + newIdea.id + "'>" + newIdea.quality +
       "</td>" +
+      "<td><a href='#' class='delete-idea' data-idea-id='" + newIdea.id + "'>Delete</a></td>" +
       "</tr>"
     );
   };
+
+  $('.ideas-index').on('click', '.delete-idea', function(e){
+    var idea = $(e.currentTarget).closest('tr');
+    var ideaId = $(this).data('idea-id');
+    $.ajax({
+      method: 'DELETE',
+      url: "/api/v1/ideas/" + ideaId + ".json",
+      dataType: "JSON",
+      success: function(){
+
+        // having trouble capturing response data
+        // 'this' does not provide idea id that can be used to enable removal
+        idea.remove();
+      },
+      error: function(req, status, err){
+        console.log('something went wrong when deleting idea', status, err);
+      }
+    });
+  });
+
 })

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -10,8 +10,9 @@ class Api::V1::IdeasController < Api::ApiController
   end
 
   def destroy
-    Idea.find(params[:id].to_i).destroy
-    respond_with head: :no_content
+    idea = Idea.find(params[:id].to_i)
+    idea.destroy
+    respond_with idea
   end
 
   private

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -1,10 +1,17 @@
 class Api::V1::IdeasController < Api::ApiController
+  before_filter :idea_params, on: [:create]
+
   def index
     respond_with Idea.all
   end
 
   def create
     respond_with Idea.create(idea_params), location: nil
+  end
+
+  def destroy
+    Idea.find(params[:id].to_i).destroy
+    respond_with head: :no_content
   end
 
   private

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -18,6 +18,9 @@
       <th>
         Quality
       </th>
+      <th>
+        Delete
+      </th>
     </tr>
   </table>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :ideas, only: [:index, :create]
+      resources :ideas, only: [:index, :create, :destroy]
     end
   end
 

--- a/spec/features/user_can_view_ideas_spec.rb
+++ b/spec/features/user_can_view_ideas_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "User can view ideas", type: :feature do
       expect(page).to have_content("Title")
       expect(page).to have_content("Body")
       expect(page).to have_content("Quality")
+      expect(page).to have_content("Delete")
     end
 
     within(".ideas-index") do

--- a/spec/requests/api_v1_ideas_controllers_spec.rb
+++ b/spec/requests/api_v1_ideas_controllers_spec.rb
@@ -46,4 +46,22 @@ RSpec.describe "Api::V1::IdeasController", type: :request do
       expect(response_body[:title]).to eq(@new_idea[:title])
     end
   end
+
+  describe "DELETE idea" do
+    before(:each) do
+      @ideas = create_list(:idea, 2)
+
+      delete "/api/v1/ideas/#{@ideas.first.id}"
+    end
+
+    it "provides a response for deleted idea" do
+      expect(response).to have_http_status(204)
+      expect(response).to be_success
+    end
+
+    it "removes the idea" do
+      expect(Idea.all).not_to include(@ideas.first)
+    end
+  end
+
 end


### PR DESCRIPTION
Implement feature for user to delete an existing idea: 
- Each idea in the list should have a link or button to "Delete" (or 𝗫, etc).
- Upon clicking "Delete", the appropriate idea should be removed from the list 
- The page should not reload when an idea is deleted.
- The idea should be removed from the database. It should not re-appear on next page load.
