### PR TITLE
Implement feature to edit existing idea

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,8 +38,8 @@ $(document).ready(function(){
     $(ideasSortedByDate).each(function(index, object){
       $('.ideas-table').append(
         "<tr class='ideas-list'>" +
-        "<td class='idea-title' data-idea-id='" + object.id + "'>" + object.title + "</td>" +
-        "<td class='idea-body' data-idea-id='" + object.id + "'>" + formatBody(object.body) + "</td>" +
+        "<td class='idea-title' id='idea-title' data-idea-id='" + object.id + "'>" + object.title + "</td>" +
+        "<td class='idea-body' id='idea-body' data-idea-id='" + object.id + "'>" + formatBody(object.body) + "</td>" +
         "<td class='idea-quality' data-idea-id='" + object.id + "' " + "data-idea-quality='" + object.quality + "'>" + object.quality + "</td>" +
         "<td class='idea-quality-up' data-idea-id='" + object.id + "' " + "data-idea-quality='" + object.quality + "'>" +
         "<input type='button' name='thumbs-up' value='thumbs up' id='thumbs-up' data-idea-id='" + object.id + "'></td>" +
@@ -85,8 +85,8 @@ $(document).ready(function(){
   function prependNewIdea(newIdea){
     $('.ideas-table tr:first').after(
       "<tr class='ideas-list'>" +
-      "<td class='idea-title' data-idea-id='" + newIdea.id + "'>" + newIdea.title + "</td>" +
-      "<td class='idea-body' data-idea-id='" + newIdea.id + "'>" + formatBody(newIdea.body) + "</td>" +
+      "<td class='idea-title' id='idea-title' data-idea-id='" + newIdea.id + "'>" + newIdea.title + "</td>" +
+      "<td class='idea-body' id ='idea-body' data-idea-id='" + newIdea.id + "'>" + formatBody(newIdea.body) + "</td>" +
       "<td class='idea-quality' data-idea-id='" + newIdea.id + "' " + "data-idea-quality='" + newIdea.quality + "'>" + newIdea.quality + "</td>" +
       "<td class='idea-quality-up' data-idea-id='" + newIdea.id + "' " + "data-idea-quality='" + newIdea.quality + "'>" +
       "<input type='button' name='thumbs-up' value='thumbs up' id='thumbs-up' data-idea-id='" + newIdea.id + "'></td>" +
@@ -109,7 +109,6 @@ $(document).ready(function(){
       } else if (currentState === "plausible") {
         return "genius";
       } else {
-        alert("Whoa, this is already quality. Is a genius idea not already the epitome of a quality idea?!");
         return currentState;
       }
     }
@@ -182,5 +181,78 @@ $(document).ready(function(){
       }
     });
   });
+
+// idea title
+
+  $('.ideas-index').delegate('.idea-title', 'click', function(e){
+    $(this).attr('contentEditable', 'true');
+  });
+
+  $('.ideas-index').delegate('.idea-title', 'keydown', function(e){
+    if(e.keyCode === 13) {
+      var updateTitle = $(e.currentTarget).text();
+      var ideaId = $(e.currentTarget).data('idea-id');
+      var patchData = { title: updateTitle };
+      e.preventDefault();
+
+      $(this).attr('contentEditable', 'false')
+
+      updateIdea(ideaId, patchData)
+    }
+  });
+
+  $('.ideas-index').delegate('.idea-title', 'blur', function(e){
+    var updateTitle = $(e.currentTarget).text();
+    var ideaId = $(e.currentTarget).data('idea-id');
+    var patchData = { title: updateTitle };
+    e.preventDefault();
+
+    $(this).attr('contentEditable', 'false')
+
+    updateIdea(ideaId, patchData)
+  });
+
+  // update idea body
+  $('.ideas-index').delegate('.idea-body', 'click', function(e){
+    $(this).attr('contentEditable', 'true');
+  });
+
+  $('.ideas-index').delegate('.idea-body', 'keydown', function(e){
+    if(e.keyCode === 13) {
+      var updateBody = $(e.currentTarget).text();
+      var ideaId = $(e.currentTarget).data('idea-id');
+      var patchData = { body: updateBody };
+      e.preventDefault();
+
+      $(this).attr('contentEditable', 'false')
+
+      updateIdea(ideaId, patchData)
+    }
+  });
+
+  $('.ideas-index').delegate('.idea-body', 'blur', function(e){
+    var updateBody = $(e.currentTarget).text();
+    var ideaId = $(e.currentTarget).data('idea-id');
+    var patchData = { body: updateBody };
+
+    $(this).attr('contentEditable', 'false')
+
+    updateIdea(ideaId, patchData)
+  });
+
+
+  function updateIdea(ideaId, patchData){
+    $.ajax({
+      method: "PATCH",
+      url: "/api/v1/ideas/" + ideaId + ".json",
+      dataType: "JSON",
+      data: patchData,
+      success: function(){
+      },
+      error: function(req, status, err){
+        console.log("something went wrong when updating title", status, err);
+      }
+    });
+  }
 
 });

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::IdeasController < Api::ApiController
   end
 
   def update
-    idea = Idea.update(params[:id], quality: idea_params[:quality])
+    idea = Idea.find(params[:id].to_i)
+    idea.update(idea_params)
     respond_with idea, json: idea
   end
 


### PR DESCRIPTION
Implement feature for user to edit existing idea: 
- When a user clicks the title or body of an idea in the list, that text should become an editable text field, pre-populated with the existing idea title or body.
- Clicking this link should not take the user to a separate "edit" page for the given idea.
- The user should be able to "commit" their changes by pressing "Enter/Return" or by clicking outside of the text field.
- If the user reloads the page, their edits will be reflected.
