### PR TITLE
extract duplication in editing idea methods to separate function

### DIFF
--- a/app/assets/javascripts/services_renderers_enablers.js.es6
+++ b/app/assets/javascripts/services_renderers_enablers.js.es6
@@ -34,6 +34,16 @@ function voteIdeaQuality(inputName){
   });
 }
 
+function updateIdeaContent(element, $object, updateContent, ideaId, errorMessage) {
+  if (element === ".idea-title") {
+    $object.parent().data().title = updateContent;
+  } else {
+    $object.parent().data().body = updateContent;
+  }
+
+  updateIdeaCall(ideaId, patchData(element, updateContent), errorMessage);
+}
+
 function enableEditIdeaOnKey(element, errorMessage){
   $('.ideas-index').delegate(element, 'keydown', function(e){
 
@@ -44,13 +54,7 @@ function enableEditIdeaOnKey(element, errorMessage){
 
       $(this).attr('contentEditable', 'false')
 
-      if(element === ".idea-title"){
-        $(this).parent().data().title = updateContent;
-      } else {
-        $(this).parent().data().body = updateContent;
-      }
-
-      updateIdeaCall(ideaId, patchData(element, updateContent), errorMessage)
+      updateIdeaContent(element, $(this), updateContent, ideaId, errorMessage);
     }
   });
 }
@@ -62,13 +66,7 @@ function enableEditIdeaOnBlur(element, errorMessage){
 
     $(this).attr('contentEditable', 'false')
 
-    if(element === ".idea-title"){
-      $(this).parent().data().title = updateContent;
-    } else {
-      $(this).parent().data().body = updateContent;
-    }
-
-    updateIdeaCall(ideaId, patchData(element, updateContent), errorMessage);
+    updateIdeaContent(element, $(this), updateContent, ideaId, errorMessage);
   });
 }
 


### PR DESCRIPTION
@martensonbj, @joshuajhun, @rrgayhart, @s-espinosa (@jdliss and I paired, so we are tagging another team...you are nearby.)
#### What's this PR do?

Resolves issue #17 . 
#### Where should the reviewer start?
- Read the issue
- Look at the functions enableEditIdeaOnKey and enableEditIdeaOnBlur, where updateIdeaContent is a new method created to DRY up the two former methods
#### How should this be manually tested?

Run `rails s` and you should be able to persist updates to idea title or body. Refresh page and edits should still be on the page. 
#### Any background context you want to provide?
#### Screenshots (if appropriate)

![demo](http://g.recordit.co/EB8EWzs0W7.gif)
#### What gif best describes this PR or how it makes you feel?

![pika pika..pikachuuuuuu](https://cdn1.vox-cdn.com/thumbor/wqO3TGo8fgiDb0pUafGhSfC29j4=/1400x0/filters:no_upscale%28%29/cdn0.vox-cdn.com/uploads/chorus_asset/file/654978/giphy.0.gif)
